### PR TITLE
Add shared math/geometry utilities and refactor motion algorithms (PID, Pure Pursuit, odometry)

### DIFF
--- a/Classes.py
+++ b/Classes.py
@@ -1,0 +1,248 @@
+# Shared utility classes/functions used across the project.
+# These are code-level helpers and not physical declarations.
+
+# Shared math constant for geometry helpers.
+PI = 3.1415926535
+
+
+# Simple mutable 2D point object.
+class Point:
+    # Build a point with x/y coordinates.
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    # Getter for x.
+    def get_x(self):
+        return self.x
+
+    # Getter for y.
+    def get_y(self):
+        return self.y
+
+    # Setter for x.
+    def set_x(self, x):
+        self.x = x
+
+    # Setter for y.
+    def set_y(self, y):
+        self.y = y
+
+    # Increment point x coordinate.
+    def increase_x(self, amount):
+        self.x += amount
+
+    # Increment point y coordinate.
+    def increase_y(self, amount):
+        self.y += amount
+
+
+# Clamp value into [low, high].
+def clamp(value, low, high):
+    if value < low:
+        return low
+    if value > high:
+        return high
+    return value
+
+
+# Return absolute value without external libraries.
+def abs_value(value):
+    if value < 0:
+        return -value
+    return value
+
+
+# Return sign of a number (+1, -1, 0).
+def sign(value):
+    if value > 0:
+        return 1
+    if value < 0:
+        return -1
+    return 0
+
+
+# Compute square root using Newton's method.
+def sqrt_value(value):
+    # Guard against negative/zero inputs.
+    if value <= 0:
+        return 0
+
+    # Seed guess with input value.
+    guess = value
+    i = 0
+    # Run a fixed number of refinement steps.
+    while i < 12:
+        guess = 0.5 * (guess + (value / guess))
+        i += 1
+    return guess
+
+
+# Compute Euclidean distance between two points.
+def distance_between(x1, y1, x2, y2):
+    dx = x2 - x1
+    dy = y2 - y1
+    return sqrt_value((dx * dx) + (dy * dy))
+
+
+# Normalize angle into [-180, 180].
+def normalize_angle_deg(angle):
+    while angle > 180:
+        angle -= 360
+    while angle < -180:
+        angle += 360
+    return angle
+
+
+# Approximate atan(z) for |z| roughly <= 1 using a short series.
+def _atan_small(z):
+    # Use additional terms for better accuracy near |z| = 1.
+    z2 = z * z
+    z3 = z2 * z
+    z5 = z3 * z2
+    z7 = z5 * z2
+    return z - (z3 / 3) + (z5 / 5) - (z7 / 7)
+
+
+# Approximate atan2(y, x) and return radians.
+def atan2(y, x):
+    # Handle vertical-axis and origin edge cases.
+    if x == 0:
+        if y > 0:
+            return PI / 2
+        if y < 0:
+            return -(PI / 2)
+        return 0
+
+    # Compute slope for atan approximation.
+    z = y / x
+
+    # Use direct approximation for moderate slopes.
+    if abs_value(z) <= 1:
+        angle = _atan_small(z)
+        if x < 0:
+            if y >= 0:
+                return angle + PI
+            return angle - PI
+        return angle
+
+    # Use atan(z) = 90 - atan(1/z) in radian form for steep slopes.
+    angle = (PI / 2) - _atan_small(1 / z)
+    if y < 0:
+        angle -= PI
+    return angle
+
+
+# Approximate atan2(y, x) and return degrees.
+def atan2_deg(y, x):
+    # Reuse radian atan2 approximation and convert to degrees.
+    return atan2(y, x) * (180 / PI)
+
+
+# Get (x, y) from either Point-like object or tuple/list.
+def get_xy(point):
+    if hasattr(point, "x") and hasattr(point, "y"):
+        return point.x, point.y
+    return point[0], point[1]
+
+
+# Project a point onto a path segment.
+def segment_projection(start, end, point):
+    # Unpack start, end, and query points.
+    sx, sy = start
+    ex, ey = end
+    px, py = point
+
+    # Build the segment vector.
+    dx = ex - sx
+    dy = ey - sy
+    seg_len2 = (dx * dx) + (dy * dy)
+
+    # If segment is degenerate, return the start point.
+    if seg_len2 == 0:
+        return start
+
+    # Compute normalized distance along segment.
+    t = (((px - sx) * dx) + ((py - sy) * dy)) / seg_len2
+    # Keep the result inside segment endpoints.
+    t = clamp(t, 0, 1)
+
+    # Return projected coordinate.
+    return (sx + (t * dx), sy + (t * dy))
+
+
+# Find the closest point on a polyline path to a position.
+def closest_point(path, position):
+    # Default best result from path start.
+    best_idx = 0
+    best_point = path[0]
+    best_dist = 999999999
+
+    # Evaluate each segment projection.
+    i = 0
+    while i < len(path) - 1:
+        projected = segment_projection(path[i], path[i + 1], position)
+        d = distance_between(projected[0], projected[1], position[0], position[1])
+        if d < best_dist:
+            best_dist = d
+            best_idx = i
+            best_point = projected
+        i += 1
+
+    # Return segment index and projected point.
+    return best_idx, best_point
+
+
+# Compute factorial using iterative multiplication.
+def factorial(value):
+    if value <= 1:
+        return 1
+    total = 1
+    i = 2
+    while i <= value:
+        total *= i
+        i += 1
+    return total
+
+
+# Convert degrees to radians.
+def deg_to_rad(degrees):
+    return degrees * (PI / 180)
+
+
+# Convert radians to degrees.
+def rad_to_deg(radians):
+    return radians * (180 / PI)
+
+
+# Approximate sine using Taylor series around zero.
+def sin_deg(degrees):
+    x = deg_to_rad(degrees)
+    # Wrap input to improve approximation stability.
+    while x > PI:
+        x -= 2 * PI
+    while x < -PI:
+        x += 2 * PI
+
+    # 7th-order sine expansion.
+    x2 = x * x
+    x3 = x2 * x
+    x5 = x3 * x2
+    x7 = x5 * x2
+    return x - (x3 / 6) + (x5 / 120) - (x7 / 5040)
+
+
+# Approximate cosine using Taylor series around zero.
+def cos_deg(degrees):
+    x = deg_to_rad(degrees)
+    # Wrap input to improve approximation stability.
+    while x > PI:
+        x -= 2 * PI
+    while x < -PI:
+        x += 2 * PI
+
+    # 6th-order cosine expansion.
+    x2 = x * x
+    x4 = x2 * x2
+    x6 = x4 * x2
+    return 1 - (x2 / 2) + (x4 / 24) - (x6 / 720)

--- a/MotionAlgs.py
+++ b/MotionAlgs.py
@@ -1,65 +1,266 @@
-from math import degrees
-from turtle import heading
-from drivetrains import drive, Gyro, GearRatio, WheelDiamater
+# Motion algorithm implementations.
+# This file contains algorithm application logic only.
 
-#This File controls all of the motion algorithms
-#This file includes PID, and Pure Pursuit
+from drivetrains import Gyro, GearRatio, WheelDiamater, drive
+from Classes import (
+    clamp,
+    distance_between,
+    normalize_angle_deg,
+    atan2_deg,
+    get_xy,
+    abs_value,
+    sign,
+    sin_deg,
+    cos_deg,
+    closest_point,
+)
+
+# Linear heading-hold PID gains.
+LinearKp = 0.55
+LinearKi = 0.0
+LinearKd = 0.05
+
+# Angular turn PID gains.
+AngularKp = 0.09
+AngularKi = 0.0
+AngularKd = 0.004
 
 
-LinearKp = 5
-LinearKi = 5
-LinearKd = 5
+# Convert drivetrain encoder ticks into linear inches traveled.
+def _motor_distance_inches(start_ticks, current_ticks):
+    # Convert raw tick delta to motor revolutions.
+    motor_revolutions = (current_ticks - start_ticks) / 4096.0
+    # Convert motor revolutions to wheel revolutions using configured gearing.
+    wheel_revolutions = motor_revolutions * GearRatio
+    # Convert wheel revolutions into inches of travel.
+    return wheel_revolutions * (WheelDiamater * 3.1415926535)
 
-AngularKp = 5
-AngularKi = 5
-AngularKd = 5
 
-def LinearPID(Distance, Speed, Target):
+# Read current heading from the configured gyro.
+def _get_heading_degrees():
+    # Some API variants accept no argument.
+    try:
+        return Gyro.get_heading()
+    # Some API variants require a unit argument.
+    except TypeError:
+        return Gyro.get_heading("degrees")
 
-    time = brain.gettime()
-    error = 0
+
+# Compute the lookahead point by walking forward from the closest point.
+def _calculate_lookahead_point(path, robot_x, robot_y, lookahead_inches):
+    # Start from the closest projected point on the path.
+    closest_segment, closest = closest_point(path, (robot_x, robot_y))
+
+    # Move forward across segments by lookahead distance.
+    remaining = lookahead_inches
+    lookahead = closest
+    i = closest_segment
+    current = closest
+
+    # Walk segment-by-segment until lookahead is located.
+    while i < len(path) - 1:
+        nxt = path[i + 1]
+        seg_len = distance_between(current[0], current[1], nxt[0], nxt[1])
+
+        # If lookahead falls on this segment, interpolate and stop.
+        if seg_len >= remaining and seg_len > 0:
+            ratio = remaining / seg_len
+            lookahead = (
+                current[0] + ((nxt[0] - current[0]) * ratio),
+                current[1] + ((nxt[1] - current[1]) * ratio),
+            )
+            break
+
+        # Otherwise consume the full segment and continue.
+        remaining -= seg_len
+        current = nxt
+        lookahead = nxt
+        i += 1
+
+    # Return the final lookahead coordinate.
+    return lookahead
+
+
+# Compute pursuit arc curvature from robot pose to lookahead point.
+def _calculate_arc_curvature(robot_x, robot_y, robot_heading_deg, lookahead_x, lookahead_y):
+    # Build vector from robot to lookahead in field frame.
+    dx = lookahead_x - robot_x
+    dy = lookahead_y - robot_y
+
+    # Transform into robot frame using inverse heading rotation.
+    x_robot = (dx * cos_deg(robot_heading_deg)) + (dy * sin_deg(robot_heading_deg))
+    y_robot = (-dx * sin_deg(robot_heading_deg)) + (dy * cos_deg(robot_heading_deg))
+
+    # Curvature for circle from robot origin to target point:
+    # k = 2*y / (x^2 + y^2)
+    denom = (x_robot * x_robot) + (y_robot * y_robot)
+    if denom == 0:
+        return 0
+    return (2 * y_robot) / denom
+
+
+# Drive a target linear distance while correcting heading with PID.
+def LinearPID(distance_inches, speed, target_heading_deg, buffer_inches=0.5, max_steps=500):
+    # Save starting encoder position.
+    start_ticks = drive.MotorPosition()
+    # Clamp requested speed to valid range once.
+    base_speed = clamp(speed, -12, 12)
+    # Store previous heading error for derivative term.
+    previous_error = 0
+    # Store integrated heading error for integral term.
     integral = 0
-    heading = Gyro.get_heading(DEGREES)
-    Driven = 0
-    while Driven < Distance:
-        MotorPose = drive.MotorPosition()
+    # Loop counter used as a safety stop.
+    steps = 0
 
-        deltaTime = brain.gettime() - time
-        pasterror = error
-        error = Target - heading
+    # Build a safe distance threshold that cannot go below zero.
+    distance_target = abs_value(distance_inches)
+    distance_buffer = abs_value(buffer_inches)
+    distance_threshold = clamp(distance_target - distance_buffer, 0, distance_target)
 
-        P = LinearKp  * error
-        integral += error * deltaTime
-        Ipid = LinearKi * integral
-        derivative = (error - pasterror) / deltaTime
-        D = LinearKd * derivative
+    # Run until distance goal (+ buffer) or safety limit is reached.
+    while steps < max_steps:
+        # Measure current heading and compute wrapped heading error.
+        heading = _get_heading_degrees()
+        error = normalize_angle_deg(target_heading_deg - heading)
 
-        PID = P + Ipid + D
+        # Update PID helper terms.
+        integral += error
+        derivative = error - previous_error
+        previous_error = error
 
-        drive.drive_tank(Speed, PID)
-        MotorDelta = MotorPose - drive.MotorPosition()
-        Revolutions = (MotorDelta/4096) * GearRatio
-        Driven = (WheelDiamater*3.14159)*Revolutions
+        # Combine PID terms into steering correction.
+        correction = (LinearKp * error) + (LinearKi * integral) + (LinearKd * derivative)
+        correction = clamp(correction, -12, 12)
 
-def AngularPID(Speed, Target, Buffer)
-    time = brain.gettime()
-    error = 0
+        # Reduce forward magnitude as turning demand increases.
+        # Keep the original drive direction (forward/reverse) from speed sign.
+        forward_mag = clamp(abs_value(base_speed) - abs_value(correction), 0, 12)
+        forward = sign(base_speed) * forward_mag
+
+        # Drive with exactly two tank values: forward speed and turn correction.
+        drive.drive_tank(forward, correction)
+
+        # Check distance completion from encoder feedback.
+        driven = abs_value(_motor_distance_inches(start_ticks, drive.MotorPosition()))
+        if driven >= distance_threshold:
+            break
+
+        # Increment loop safety counter.
+        steps += 1
+
+    # Stop drivetrain at the end of the routine.
+    drive.drive_tank(0, 0)
+
+
+# Turn to a target heading using angular PID.
+def AngularPID(speed, target_heading_deg, buffer_deg=1.5, max_steps=400):
+    # Clamp requested speed magnitude for turn scaling.
+    turn_scale = abs_value(clamp(speed, -12, 12))
+    # Store previous heading error for derivative term.
+    previous_error = 0
+    # Store integrated heading error for integral term.
     integral = 0
-    heading = Gyro.get_heading(DEGREES)
-    while heading + Buffer < Target or heading - Buffer > Target:
-        MotorPose = drive.MotorPosition()
+    # Loop counter used as a safety stop.
+    steps = 0
 
-        deltaTime = brain.gettime() - time
-        pasterror = error
-        error = Target - heading
+    # Run until angular buffer is met or safety limit is reached.
+    while steps < max_steps:
+        # Measure current heading and compute shortest-turn error.
+        heading = _get_heading_degrees()
+        error = normalize_angle_deg(target_heading_deg - heading)
 
-        P = LinearKp  * error
-        integral += error * deltaTime
-        Ipid = LinearKi * integral
-        derivative = (error - pasterror) / deltaTime
-        D = LinearKd * derivative
+        # Update PID helper terms.
+        integral += error
+        derivative = error - previous_error
+        previous_error = error
+
+        # Build turn output and clamp to drivetrain range.
+        pid = (AngularKp * error) + (AngularKi * integral) + (AngularKd * derivative)
+        correction = clamp(pid * turn_scale, -12, 12)
+
+        # Drive with exactly two tank values: forward speed and turn correction.
+        drive.drive_tank(0, correction)
+
+        # Stop once within angular tolerance.
+        if abs_value(error) <= buffer_deg:
+            break
+
+        # Increment loop safety counter.
+        steps += 1
+
+    # Stop drivetrain at the end of the routine.
+    drive.drive_tank(0, 0)
 
 
-        PID = P + Ipid + D
+# Follow a path using pure pursuit with explicit readable steps.
+def PurePursuit(path, tracker, speed=6, lookahead_inches=8, stop_tolerance_inches=1, max_steps=1200):
+    # Convert input points into a clean tuple list.
+    clean_path = []
+    for p in path:
+        x, y = get_xy(p)
+        clean_path.append((x, y))
 
-        drive.drive_tank(0, (Speed*PID)/12)
+    # Require at least one line segment.
+    if len(clean_path) < 2:
+        return
+
+    # Clamp base forward speed once.
+    base_speed = clamp(speed, -12, 12)
+    steps = 0
+
+    # Run path following loop.
+    while steps < max_steps:
+        # Read robot pose from tracker and gyro.
+        robot_pos = tracker.get_pos()
+        robot_x, robot_y = get_xy(robot_pos)
+        robot_heading_deg = _get_heading_degrees()
+
+        # STEP 1: Calculate lookahead point on the path.
+        lookahead_x, lookahead_y = _calculate_lookahead_point(clean_path, robot_x, robot_y, lookahead_inches)
+
+        # STEP 2: Calculate the arc curvature from robot to lookahead point.
+        curvature = _calculate_arc_curvature(robot_x, robot_y, robot_heading_deg, lookahead_x, lookahead_y)
+
+        # STEP 3: Convert curvature to motor drive values for forward motion.
+        # Scale curvature by speed to create turn correction.
+        correction = clamp(curvature * abs_value(base_speed), -12, 12)
+        # Reduce forward magnitude during aggressive turns, keep direction.
+        forward_mag = clamp(abs_value(base_speed) - abs_value(correction), 0, 12)
+        forward = sign(base_speed) * forward_mag
+
+        # Drive with exactly two tank values: forward speed and turn correction.
+        drive.drive_tank(forward, correction)
+
+        # Stop when close enough to path endpoint.
+        end_x, end_y = clean_path[len(clean_path) - 1]
+        if distance_between(robot_x, robot_y, end_x, end_y) <= stop_tolerance_inches:
+            break
+
+        # Increment loop safety counter.
+        steps += 1
+
+    # Stop drivetrain at the end of the routine.
+    drive.drive_tank(0, 0)
+
+
+# Drive to a field point using odometry + heading/distance PID.
+def OdomDriveToPoint(target_x, target_y, tracker, speed=6, heading_buffer_deg=1.5, distance_buffer_inches=0.5):
+    # Read current robot position from the tracker.
+    robot_pos = tracker.get_pos()
+    robot_x, robot_y = get_xy(robot_pos)
+
+    # Build target vector from robot to requested point.
+    delta_x = target_x - robot_x
+    delta_y = target_y - robot_y
+
+    # Compute angle we must face to drive straight to the point.
+    target_heading_deg = atan2_deg(delta_y, delta_x)
+
+    # Compute linear distance needed to reach the point.
+    distance_inches = distance_between(robot_x, robot_y, target_x, target_y)
+
+    # First turn to the desired heading.
+    AngularPID(speed, target_heading_deg, heading_buffer_deg)
+
+    # Then drive the computed distance while holding that heading.
+    LinearPID(distance_inches, speed, target_heading_deg, distance_buffer_inches)


### PR DESCRIPTION
### Motivation
- Provide a single, testable utilities module for common math, geometry, and trig helpers to simplify motion algorithm code and remove ad-hoc implementations from the motion file.
- Rework motion control routines to use clearer helper functions, improve numerical stability, and unify drivetrain/gyro interactions for PID, Pure Pursuit, and odometry-driven routines.

### Description
- Add `Classes.py` containing `Point`, `clamp`, `abs_value`, `sign`, `sqrt_value`, `distance_between`, angle normalization and `atan2`/`atan2_deg` approximations, trig approximations (`sin_deg`, `cos_deg`), `closest_point`/`segment_projection`, `factorial`, and conversion helpers (`deg_to_rad`, `rad_to_deg`).
- Replace and refactor `MotionAlgs.py` to import helpers from `Classes.py`, define PID gain constants (`LinearKp`, `LinearKi`, `LinearKd`, `AngularKp`, `AngularKi`, `AngularKd`), and add internal helpers `_motor_distance_inches`, `_get_heading_degrees`, `_calculate_lookahead_point`, and `_calculate_arc_curvature` for clarity.
- Reimplement `LinearPID`, `AngularPID`, `PurePursuit`, and `OdomDriveToPoint` with explicit loop safety counters, consistent use of `drive.drive_tank`, encoder-based distance calculation, normalized heading errors via `normalize_angle_deg`, and clearer speed/correction clamping.
- Remove legacy/turtle/brain API usage and consolidate gyro/drive interactions behind small adapter helpers for broader API compatibility.

### Testing
- Ran the project unit test suite using `pytest` to exercise geometry utilities and motion algorithm smoke paths, and all tests completed successfully.
- Performed a quick static check with `flake8` for obvious style issues which reported no critical failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b331a8af88832b852cbef9940503ae)