### PR TITLE
Align Venice API usage

### DIFF
--- a/Classes.py
+++ b/Classes.py
@@ -21,6 +21,7 @@ def _motor_distance_inches(start_ticks, current_ticks):
 
 # Read current heading from a Venice inertial sensor.
 def _get_heading_degrees(gyro):
+    # Venice InertialSensor.get_heading requires an explicit RotationUnit argument.
     return gyro.get_heading(RotationUnit.DEGREES)
 
 

--- a/Classes.py
+++ b/Classes.py
@@ -1,6 +1,9 @@
 # Shared utility classes/functions used across the project.
 # These are code-level helpers and not physical declarations.
 
+from venice import RotationUnit
+
+
 # Shared math constant for geometry helpers.
 PI = 3.1415926535
 
@@ -16,14 +19,9 @@ def _motor_distance_inches(start_ticks, current_ticks):
     return wheel_revolutions * (WheelDiamater * 3.1415926535)
 
 
-# Read current heading from the configured gyro.
-def _get_heading_degrees():
-    # Some API variants accept no argument.
-    try:
-        return Gyro.get_heading()
-    # Some API variants require a unit argument.
-    except TypeError:
-        return Gyro.get_heading("degrees")
+# Read current heading from a Venice inertial sensor.
+def _get_heading_degrees(gyro):
+    return gyro.get_heading(RotationUnit.DEGREES)
 
 
 # Compute the lookahead point by walking forward from the closest point.

--- a/MotionAlgs.py
+++ b/MotionAlgs.py
@@ -27,6 +27,7 @@ AngularKd = 0.004
 
 # Convert drivetrain encoder ticks into linear inches traveled.
 def _motor_distance_inches(start_ticks, current_ticks):
+    # MotorPosition() returns Venice raw encoder ticks, so convert ticks to inches.
     # Convert raw tick delta to motor revolutions.
     motor_revolutions = (current_ticks - start_ticks) / 4096.0
     # Convert motor revolutions to wheel revolutions using configured gearing.
@@ -37,10 +38,12 @@ def _motor_distance_inches(start_ticks, current_ticks):
 
 # Read current heading from the configured Venice inertial sensor.
 def _get_heading_degrees():
+    # Venice requires the unit argument; degrees match the rest of this file's math.
     return Gyro.get_heading(RotationUnit.DEGREES)
 
 
 def sign(value):
+    """Return the direction multiplier used to preserve positive/negative speeds."""
     if value < 0:
         return -1
     return 1
@@ -138,7 +141,7 @@ def LinearPID(distance_inches, speed, target_heading_deg, buffer_inches=0.5, max
         # Drive with exactly two tank values: forward speed and turn correction.
         drive.drive_tank(adjusted_speed, correction)
 
-        # Check distance completion from encoder feedback.
+        # Check distance completion from Venice motor encoder feedback.
         driven = abs_value(_motor_distance_inches(start_ticks, drive.MotorPosition()))
         if driven >= (abs_value(distance_inches) - buffer_inches):
             break

--- a/MotionAlgs.py
+++ b/MotionAlgs.py
@@ -1,6 +1,7 @@
 # Motion algorithm implementations.
 # This file contains algorithm application logic only.
 
+from venice import RotationUnit
 from drivetrains import Gyro, GearRatio, WheelDiamater, drive
 from Classes import (
     clamp,
@@ -9,15 +10,8 @@ from Classes import (
     atan2_deg,
     get_xy,
     abs_value,
-    sin_deg,
-    cos_deg,
     closest_point,
-    _motor_distance_inches,
-    _get_heading_degrees,
-    _calculate_lookahead_point,
-    _calculate_arc_curvature,
     Point
-
 )
 
 # Linear heading-hold PID gains.
@@ -41,14 +35,15 @@ def _motor_distance_inches(start_ticks, current_ticks):
     return wheel_revolutions * (WheelDiamater * 3.1415926535)
 
 
-# Read current heading from the configured gyro.
+# Read current heading from the configured Venice inertial sensor.
 def _get_heading_degrees():
-    # Some API variants accept no argument.
-    try:
-        return Gyro.get_heading()
-    # Some API variants require a unit argument.
-    except TypeError:
-        return Gyro.get_heading("degrees")
+    return Gyro.get_heading(RotationUnit.DEGREES)
+
+
+def sign(value):
+    if value < 0:
+        return -1
+    return 1
 
 
 # Compute the lookahead point by walking forward from the closest point.
@@ -119,9 +114,6 @@ def LinearPID(distance_inches, speed, target_heading_deg, buffer_inches=0.5, max
     integral = 0
     # Loop counter used as a safety stop.
     steps = 0
-
-    from drivetrains import drive, Gyro, GearRatio, WheelDiamater
-    from Classes import point
 
     # Run until distance goal (+ buffer) or safety limit is reached.
     while steps < max_steps:

--- a/drivetrains.py
+++ b/drivetrains.py
@@ -1,5 +1,5 @@
-from venice import Direction, Gearset, Motor, RotationSensor, RotationUnit
-from Classes import Point, factorial, sin_deg, cos_deg, deg_to_rad
+from venice import Direction, Gearset, InertialSensor, Motor, RotationSensor, RotationUnit
+from Classes import Point, sin_deg, cos_deg
 
 
 """This file is where you will define your drivetrain
@@ -45,6 +45,14 @@ OdomDiameter  = 5
 # Each drivetrain contaitns the logic on how to move given Forward velocity, and how much you want to turn
 
 
+def clamp_voltage(voltage):
+    return max(-12, min(12, voltage))
+
+
+def tank_voltages(forward, turn):
+    return clamp_voltage(forward + turn), clamp_voltage(forward - turn)
+
+
 def create_motor(port: int) -> Motor:
     port_abs: int = abs(port)
     if port < 0:
@@ -70,25 +78,19 @@ class TankDrivetrain:
         # and how fast you want to turn. This means regardless of our drivetrain type,
         #  we can call the same function!
 
-        if velocity + turn > 12 or velocity + turn < -12:
-            right_Norm = velocity + turn - 12
-        elif velocity - turn > 12 or velocity - turn < -12:
-            left_norm = velocity - turn -12
-
-        right_norm = 0
-        left_norm = 0
+        left_voltage, right_voltage = tank_voltages(velocity, turn)
 
         for m in self.left_motors:
-            m.set_voltage(velocity + turn - left_norm)
+            m.set_voltage(left_voltage)
         for m in self.right_motors:
-            m.set_voltage(velocity - turn - right_norm)
+            m.set_voltage(right_voltage)
 
     def MotorPosition(self):
         Amt_Motors = 0
         Total = 0
         for m in self.left_motors + self.right_motors:
             Amt_Motors += 1
-            Total += m.raw_position()
+            Total += m.get_raw_position()
         return Total / Amt_Motors
 
 
@@ -101,18 +103,8 @@ class HolomonicDrive:
 
     def drive_tank(self, Forward, Rotate):
 
-        right_norm = 0
-        left_norm = 0
-
-        if Forward + Rotate > 12 or Forward + Rotate < -12:
-            right_Norm = Forward + Rotate - 12
-        elif Forward - Rotate > 12 or Forward - Rotate < -12:
-            left_norm = Forward - Rotate -12
-
-        FL = max(-12, min(12, Forward + Rotate - left_norm))
-        FR = max(-12, min(12, Forward - Rotate - right_norm))
-        BL = max(-12, min(12, Forward + Rotate - left_norm))
-        BR = max(-12, min(12, Forward - Rotate - right_norm))
+        FL, FR = tank_voltages(Forward, Rotate)
+        BL, BR = FL, FR
 
         self.LeftFront.set_voltage(FL)
         self.RightFront.set_voltage(FR)
@@ -120,8 +112,10 @@ class HolomonicDrive:
         self.RightBack.set_voltage(BR)
 
     def drive_holomonic(self, Forward, Lateral, Rotate):
-        FL = max(-12, min(12, Forward + Lateral + Rotate))
-        BR = max(-12, min(12, Forward + Lateral - Rotate))
+        FL = clamp_voltage(Forward + Lateral + Rotate)
+        FR = clamp_voltage(Forward - Lateral - Rotate)
+        BL = clamp_voltage(Forward - Lateral + Rotate)
+        BR = clamp_voltage(Forward + Lateral - Rotate)
 
         self.LeftFront.set_voltage(FL)
         self.RightFront.set_voltage(FR)
@@ -130,10 +124,10 @@ class HolomonicDrive:
 
     def MotorPosition(self):
         Total = 0
-        Total += self.LeftFront.raw_position()
-        Total += self.RightFront.raw_position()
-        Total += self.RightBack.raw_position()
-        Total += self.LeftBack.raw_position()
+        Total += self.LeftFront.get_raw_position()
+        Total += self.RightFront.get_raw_position()
+        Total += self.RightBack.get_raw_position()
+        Total += self.LeftBack.get_raw_position()
 
         return Total / 4
 
@@ -149,22 +143,9 @@ class HolomonicDrive6:
 
     def drive_tank(self, Forward, Rotate):
 
-        right_norm = 0
-        left_norm = 0
-
-        if Forward + Rotate > 12 or Forward + Rotate < -12:
-            right_Norm = Forward + Rotate - 12
-        elif Forward - Rotate > 12 or Forward - Rotate < -12:
-            left_norm = Forward - Rotate -12
-
-
-
-        FL = max(-12, min(12, Forward + Rotate - left_norm))
-        FR = max(-12, min(12, Forward - Rotate - right_norm))
-        ML = max(-12, min(12, Forward + Rotate - left_norm))
-        MR = max(-12, min(12, Forward - Rotate - right_norm))
-        BL = max(-12, min(12, Forward + Rotate - left_norm))
-        BR = max(-12, min(12, Forward - Rotate - right_norm))
+        FL, FR = tank_voltages(Forward, Rotate)
+        ML, MR = FL, FR
+        BL, BR = FL, FR
 
         self.LeftFront.set_voltage(FL)
         self.RightFront.set_voltage(FR)
@@ -174,12 +155,12 @@ class HolomonicDrive6:
         self.RightBack.set_voltage(BR)
 
     def drive_holomonic(self, Forward, Lateral, Rotate):
-        FL = max(-12, min(12, Forward + Lateral + Rotate))
-        FR = max(-12, min(12, Forward - Lateral - Rotate))
-        ML = max(-12, min(12, Forward + Rotate))
-        MR = max(-12, min(12, Forward - Rotate))
-        BL = max(-12, min(12, Forward - Lateral + Rotate))
-        BR = max(-12, min(12, Forward + Lateral - Rotate))
+        FL = clamp_voltage(Forward + Lateral + Rotate)
+        FR = clamp_voltage(Forward - Lateral - Rotate)
+        ML = clamp_voltage(Forward + Rotate)
+        MR = clamp_voltage(Forward - Rotate)
+        BL = clamp_voltage(Forward - Lateral + Rotate)
+        BR = clamp_voltage(Forward + Lateral - Rotate)
 
         self.LeftFront.set_voltage(FL)
         self.RightFront.set_voltage(FR)
@@ -190,12 +171,12 @@ class HolomonicDrive6:
 
     def MotorPosition(self):
         Total = 0
-        Total += self.LeftFront.raw_position()
-        Total += self.RightFront.raw_position()
-        Total += self.RightMiddle.raw_position()
-        Total += self.LeftMiddle.raw_position()
-        Total += self.RightBack.raw_position()
-        Total += self.LeftBack.raw_position()
+        Total += self.LeftFront.get_raw_position()
+        Total += self.RightFront.get_raw_position()
+        Total += self.RightMiddle.get_raw_position()
+        Total += self.LeftMiddle.get_raw_position()
+        Total += self.RightBack.get_raw_position()
+        Total += self.LeftBack.get_raw_position()
 
         return Total / 6
 
@@ -208,14 +189,14 @@ class TrackingNoOdom:
         self.WheelDiameter = WheelDiameter
 
         # Store previous motor position to calculate delta
-        self.prev_motor = self.drive.MotorPosition
+        self.prev_motor = self.drive.MotorPosition()
 
     # This function continuously updates the position of the robot
     # Each loop it takes the information from the motors and updates the positions
     def updatePose(self):
         while True:
             # Read current motor rotation
-            curr_motor = self.drive.MotorPosition
+            curr_motor = self.drive.MotorPosition()
 
             # Calculate change since last update
             delta_motor = curr_motor - self.prev_motor
@@ -223,7 +204,7 @@ class TrackingNoOdom:
             DistanceMoved = Wheel_rotations * 3.14159 * self.WheelDiameter
 
             # Update global position using current heading
-            heading = self.gyro.get_heading
+            heading = self.gyro.get_heading(RotationUnit.DEGREES)
             self.pos.increase_x(DistanceMoved * cos_deg(heading))
             self.pos.increase_y(DistanceMoved * sin_deg(heading))
 
@@ -242,21 +223,21 @@ class Tracking1Odom:
         self.OdomPod1 = create_rotation(OdomPorts)
 
         # Store previous pod position to calculate delta
-        self.prev_odom = self.OdomPod1.position(DEGREES)
+        self.prev_odom = self.OdomPod1.get_position(RotationUnit.DEGREES)
 
     # This function continuously updates the position of the robot
     # Each loop it takes the information from the odom pod and updates the positions
     def updatePose(self):
         while True:
             # Read current odom pod rotation
-            curr_odom = self.OdomPod1.position(DEGREES)
+            curr_odom = self.OdomPod1.get_position(RotationUnit.DEGREES)
 
             # Calculate change since last update
             delta_rot = curr_odom - self.prev_odom
             DistanceMoved = delta_rot * self.OdomDiameter * 3.14159 / 360  # convert degrees to revolutions
 
             # Update global position using current heading
-            heading = self.gyro.get_heading
+            heading = self.gyro.get_heading(RotationUnit.DEGREES)
             self.pos.increase_x(DistanceMoved * cos_deg(heading))
             self.pos.increase_y(DistanceMoved * sin_deg(heading))
 
@@ -279,8 +260,8 @@ class Tracking2Odom:
         self.OdomPodHorizontal = create_rotation(OdomPorts[1])
 
         # Store previous positions for delta calculation
-        self.prev_vert = self.OdomPodVertical.position(DEGREES)
-        self.prev_horiz = self.OdomPodHorizontal.position(DEGREES)
+        self.prev_vert = self.OdomPodVertical.get_position(RotationUnit.DEGREES)
+        self.prev_horiz = self.OdomPodHorizontal.get_position(RotationUnit.DEGREES)
 
     # This function continuously updates the position of the robot
     # Each loop it takes the information from the odom pods and updates the positions
@@ -288,15 +269,15 @@ class Tracking2Odom:
         while True:
 
             # Read current odom pod rotations
-            curr_vert = self.OdomPodVertical.position(DEGREES)
-            curr_horiz = self.OdomPodHorizontal.position(DEGREES)
+            curr_vert = self.OdomPodVertical.get_position(RotationUnit.DEGREES)
+            curr_horiz = self.OdomPodHorizontal.get_position(RotationUnit.DEGREES)
 
             # Compute how much each pod moved since last update
             delta_vert = (curr_vert - self.prev_vert) * self.OdomDiameter * 3.14159 / 360
             delta_horiz = (curr_horiz - self.prev_horiz) * self.OdomDiameter * 3.14159 / 360
 
             # Rotate local movement by current heading to get field coordinates
-            heading = self.gyro.get_heading
+            heading = self.gyro.get_heading(RotationUnit.DEGREES)
             self.pos.increase_x(delta_horiz * cos_deg(heading) - delta_vert * sin_deg(heading))
             self.pos.increase_y(delta_horiz * sin_deg(heading) + delta_vert * cos_deg(heading))
 
@@ -316,6 +297,7 @@ elif DriveTrainType == "holomonic":
 elif DriveTrainType == "holomonic6":
     drive = HolomonicDrive6(LeftMotors, RightMotors)
 else:
+    drive = None
     print("ded")
 
 if AmtOdom == 0:

--- a/drivetrains.py
+++ b/drivetrains.py
@@ -2,6 +2,12 @@ from venice import Direction, Gearset, InertialSensor, Motor, RotationSensor, Ro
 from Classes import Point, sin_deg, cos_deg
 
 
+# Venice API notes:
+# - Motor and RotationSensor constructors both take a Smart Port number plus a Direction.
+# - Encoder/rotation reads use explicit RotationUnit values where the API requires units.
+# - Motor voltage commands are in volts, so drivetrain outputs are clamped to +/-12V.
+
+
 """This file is where you will define your drivetrain
 The variable DriveTrainType is what defines what dirve train you have, the current drivetrains that are
 supported are these (Name followed for the variable in paranthesis)
@@ -46,24 +52,39 @@ OdomDiameter  = 5
 
 
 def clamp_voltage(voltage):
+    """Keep every Venice Motor.set_voltage command inside the legal +/-12V range."""
     return max(-12, min(12, voltage))
 
 
 def tank_voltages(forward, turn):
-    return clamp_voltage(forward + turn), clamp_voltage(forward - turn)
+    """Convert forward/turn requests into left/right tank-drive voltages."""
+    left_voltage = clamp_voltage(forward + turn)
+    right_voltage = clamp_voltage(forward - turn)
+    return left_voltage, right_voltage
+
+
+def _first_port(port_or_ports):
+    """Allow one-odom configs to pass either a single port or a one-item port list."""
+    if isinstance(port_or_ports, list):
+        return port_or_ports[0]
+    return port_or_ports
 
 
 def create_motor(port: int) -> Motor:
+    """Create a Venice Motor, using a negative port number to mark it reversed."""
     port_abs: int = abs(port)
     if port < 0:
+        # Venice expects the reversal as Direction.REVERSE, not as a negative port.
         return Motor(port_abs, Direction.REVERSE, Gearset.GREEN)
     else:
         return Motor(port_abs, Direction.FORWARD, Gearset.GREEN)
 
 
 def create_rotation(port: int) -> RotationSensor:
+    """Create a Venice RotationSensor, using a negative port number to mark it reversed."""
     port_abs: int = abs(port)
     if port < 0:
+        # RotationSensor follows the same Direction enum pattern as Motor.
         return RotationSensor(port_abs, Direction.REVERSE)
     else:
         return RotationSensor(port_abs, Direction.FORWARD)
@@ -86,6 +107,7 @@ class TankDrivetrain:
             m.set_voltage(right_voltage)
 
     def MotorPosition(self):
+        # Venice exposes raw encoder ticks with get_raw_position().
         Amt_Motors = 0
         Total = 0
         for m in self.left_motors + self.right_motors:
@@ -102,7 +124,7 @@ class HolomonicDrive:
         self.RightBack = create_motor(right_ports[1])
 
     def drive_tank(self, Forward, Rotate):
-
+        # Reuse tank math so autonomous routines can call drive_tank on any drive type.
         FL, FR = tank_voltages(Forward, Rotate)
         BL, BR = FL, FR
 
@@ -112,6 +134,7 @@ class HolomonicDrive:
         self.RightBack.set_voltage(BR)
 
     def drive_holomonic(self, Forward, Lateral, Rotate):
+        # X-drive/mecanum mixing: combine forward, strafe, and turn, then clamp volts.
         FL = clamp_voltage(Forward + Lateral + Rotate)
         FR = clamp_voltage(Forward - Lateral - Rotate)
         BL = clamp_voltage(Forward - Lateral + Rotate)
@@ -123,6 +146,7 @@ class HolomonicDrive:
         self.RightBack.set_voltage(BR)
 
     def MotorPosition(self):
+        # Average all motor encoders so PID distance checks use one drivetrain value.
         Total = 0
         Total += self.LeftFront.get_raw_position()
         Total += self.RightFront.get_raw_position()
@@ -142,7 +166,7 @@ class HolomonicDrive6:
         self.RightBack = create_motor(right_ports[2])
 
     def drive_tank(self, Forward, Rotate):
-
+        # Six-motor tank mode mirrors each side's voltage across front/middle/back.
         FL, FR = tank_voltages(Forward, Rotate)
         ML, MR = FL, FR
         BL, BR = FL, FR
@@ -155,6 +179,7 @@ class HolomonicDrive6:
         self.RightBack.set_voltage(BR)
 
     def drive_holomonic(self, Forward, Lateral, Rotate):
+        # Six-motor holonomic mixing keeps middle motors out of the strafe term.
         FL = clamp_voltage(Forward + Lateral + Rotate)
         FR = clamp_voltage(Forward - Lateral - Rotate)
         ML = clamp_voltage(Forward + Rotate)
@@ -170,6 +195,7 @@ class HolomonicDrive6:
         self.RightBack.set_voltage(BR)
 
     def MotorPosition(self):
+        # Average all six raw motor encoder positions.
         Total = 0
         Total += self.LeftFront.get_raw_position()
         Total += self.RightFront.get_raw_position()
@@ -204,6 +230,7 @@ class TrackingNoOdom:
             DistanceMoved = Wheel_rotations * 3.14159 * self.WheelDiameter
 
             # Update global position using current heading
+            # Venice requires an explicit RotationUnit for heading reads.
             heading = self.gyro.get_heading(RotationUnit.DEGREES)
             self.pos.increase_x(DistanceMoved * cos_deg(heading))
             self.pos.increase_y(DistanceMoved * sin_deg(heading))
@@ -220,9 +247,10 @@ class Tracking1Odom:
         self.gyro = Gyro
         self.pos = Point(0, 0)
         self.OdomDiameter = OdomDiameter
-        self.OdomPod1 = create_rotation(OdomPorts)
+        self.OdomPod1 = create_rotation(_first_port(OdomPorts))
 
         # Store previous pod position to calculate delta
+        # RotationSensor.get_position() also requires an explicit RotationUnit.
         self.prev_odom = self.OdomPod1.get_position(RotationUnit.DEGREES)
 
     # This function continuously updates the position of the robot
@@ -260,6 +288,7 @@ class Tracking2Odom:
         self.OdomPodHorizontal = create_rotation(OdomPorts[1])
 
         # Store previous positions for delta calculation
+        # Store both odom pods in degrees so the distance math below can divide by 360.
         self.prev_vert = self.OdomPodVertical.get_position(RotationUnit.DEGREES)
         self.prev_horiz = self.OdomPodHorizontal.get_position(RotationUnit.DEGREES)
 


### PR DESCRIPTION
### Motivation
- Update the motion/drivetrain code to match the Venice runtime reference so sensor and motor calls use the documented API shapes and units. 
- Fix inconsistent/drifting motor/rotation access and clamp/voltage math that could produce undefined variables or out-of-range outputs. 
- Make odometry and heading reads robust by consistently passing unit arguments and using the documented accessors. 

### Description
- Import and use the Venice types required by the reference by switching to `InertialSensor` and `RotationUnit` where appropriate and adding `from venice import RotationUnit` to helper files. 
- Replace legacy/no-argument calls with documented methods by using `gyro.get_heading(RotationUnit.DEGREES)`, rotation sensor `.get_position(RotationUnit.DEGREES)`, and motor `.get_raw_position()` (and calling `MotorPosition()` where needed). 
- Add `clamp_voltage` and `tank_voltages` helpers and a `sign()` helper, and refactor tank/holonomic drive routines to compute and clamp left/right voltages consistently instead of using several ad-hoc/undefined variables. 
- Fix odometry/tracking routines to call sensor methods correctly (invoke `MotorPosition()` and pass `RotationUnit.DEGREES`) and remove broken local imports inside `LinearPID`. 

### Testing
- Ran `python -m py_compile Classes.py MotionAlgs.py drivetrains.py` and compilation succeeded with no syntax errors. 
- Scanned the tree with `rg` for old/incorrect patterns (legacy `.raw_position(`, `.position(`, no-argument `get_heading()` and other known mismatches) to verify replacements; that search returned only the updated/expected usages. 
- No automated runtime tests were present in the repository, so only static checks above were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a091282f224832b8b97f6b796f2942e)